### PR TITLE
Show percentage share of each category in dashboard.

### DIFF
--- a/src/components/BudgetItem.tsx
+++ b/src/components/BudgetItem.tsx
@@ -10,13 +10,14 @@ import {
 import { useMemo } from "react";
 import { Icons } from "../constants/categories";
 import { useBudgetItemStyles } from "../theme/modules/budgetItem.styles";
-import { formatCurrency } from "../utils";
+import { formatCurrency, getPercentage } from "../utils";
 
 interface IBudgetItemProps {
   showSelection?: boolean;
   selection?: string[];
   onSelectionChange?: React.ChangeEventHandler<HTMLInputElement>;
   data: [string, SummaryItem];
+  overallSpent: number;
 }
 
 function BudgetItem({
@@ -24,6 +25,7 @@ function BudgetItem({
   selection,
   onSelectionChange,
   data,
+  overallSpent,
 }: Readonly<IBudgetItemProps>) {
   const [category, { subCategories, total }] = data;
 
@@ -35,6 +37,11 @@ function BudgetItem({
     }));
   }, [data]);
 
+  const share = useMemo(
+    () => getPercentage(total, overallSpent),
+    [total, overallSpent]
+  );
+
   return (
     <Box className={classes.item}>
       {showSelection && (
@@ -43,16 +50,17 @@ function BudgetItem({
           value={category}
           checked={selection?.includes(category)}
           onChange={onSelectionChange}
+          className={classes.elevate}
         />
       )}
-      <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
+      <Box className={classes.elevate} sx={{ width: "100%" }}>
         <Group align="center" mb={2} position="apart">
           <Badge color={subCategories[0].color} size="sm" radius="sm">
             {category}
           </Badge>
-          <Text fw="bold">{formatCurrency(total)}</Text>
+          <Text fw="bold">{formatCurrency(total)} </Text>
         </Group>
-        <Group spacing={6}>
+        <Group spacing={6} align="center">
           {subItems.map(({ label, value, color, Icon }) => (
             <Tooltip
               label={`${label}: ${formatCurrency(value)}`}
@@ -65,8 +73,18 @@ function BudgetItem({
               </ThemeIcon>
             </Tooltip>
           ))}
+          <Text color="dimmed" fz="xs" ml="auto" pt={1}>
+            ({share}%)
+          </Text>
         </Group>
       </Box>
+      <Box
+        className={classes.share}
+        sx={(theme) => ({
+          width: `${share}%`,
+          backgroundColor: theme.colors[subCategories[0].color][7],
+        })}
+      />
     </Box>
   );
 }

--- a/src/modules/home/BudgetBreakdown.tsx
+++ b/src/modules/home/BudgetBreakdown.tsx
@@ -223,20 +223,16 @@ export default function BudgetBreakdown({
       <Divider my="xs" />
       <ScrollArea h={`calc(100vh - ${isMobile ? 272 : 242}px)`}>
         <SimpleGrid cols={1} spacing="xs">
-          {Object.entries(summary?.response?.summary ?? {})
-            ?.sort(
-              (firstItem, secondItem) =>
-                secondItem[1]?.total - firstItem[1]?.total
-            )
-            ?.map((item) => (
-              <BudgetItem
-                key={item[0]}
-                data={item}
-                showSelection={showSelection}
-                selection={selection}
-                onSelectionChange={handleSelection}
-              />
-            ))}
+          {Object.entries(summary?.response?.summary ?? {})?.map((item) => (
+            <BudgetItem
+              key={item[0]}
+              data={item}
+              overallSpent={summary?.response.total ?? 0}
+              showSelection={showSelection}
+              selection={selection}
+              onSelectionChange={handleSelection}
+            />
+          ))}
         </SimpleGrid>
       </ScrollArea>
       <Group grow spacing="xs" align="flex-start" mt="auto">

--- a/src/modules/plans/components/PlanSummary.tsx
+++ b/src/modules/plans/components/PlanSummary.tsx
@@ -88,7 +88,11 @@ function PlanSummary() {
             </Box>
           )}
           {summaryData?.map((data) => (
-            <BudgetItem data={data} key={data[0]} />
+            <BudgetItem
+              data={data}
+              key={data[0]}
+              overallSpent={summary?.response.total ?? 0}
+            />
           ))}
         </SimpleGrid>
       </ScrollArea>

--- a/src/theme/modules/budgetItem.styles.ts
+++ b/src/theme/modules/budgetItem.styles.ts
@@ -12,5 +12,18 @@ export const useBudgetItemStyles = createStyles((theme) => ({
     alignItems: "center",
     width: "100%",
     gap: 8,
+    position: "relative",
+  },
+  elevate: {
+    zIndex: 1,
+  },
+  share: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    height: "100%",
+    opacity: 0.1,
+    borderRadius: theme.radius.sm,
+    zIndex: 0,
   },
 }));


### PR DESCRIPTION
On the dashboard, utilize the budget breakdown item to also show a percentage share graph for quick estimation of which category shares the maximum amount of the total expense. 

Also provide a handy percentage value for each category. 

![image](https://github.com/user-attachments/assets/97372ead-1bbf-4931-8638-ee5c51cce2ea)
