### PR TITLE
Redesign the Sidebar Navigation to provide more free space on desktop.

### DIFF
--- a/src/components/app-info/AppInfo.tsx
+++ b/src/components/app-info/AppInfo.tsx
@@ -1,15 +1,26 @@
-import { Group, GroupProps, Modal, Text } from "@mantine/core";
+import {
+  Group,
+  GroupProps,
+  Menu,
+  Modal,
+  Text,
+  ThemeIcon,
+  UnstyledButton,
+} from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { IconPoint } from "@tabler/icons-react";
+import { IconInfoCircle, IconPoint } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useCurrentUser } from "../../context/user.context";
 import { useMediaMatch } from "../../hooks/media-match";
 import { updateUserDetails } from "../../services/user.service";
+import { useNavBtnStyle } from "../../theme/modules/layout.styles";
 import Changelog from "./Changelog";
 
-export default function AppInfo(props: Readonly<GroupProps>) {
+export default function AppInfo(
+  props: Readonly<GroupProps & { type: "menu" | "text" }>
+) {
   const [showVersions, { open, close }] = useDisclosure(false);
 
   const isMobile = useMediaMatch();
@@ -32,29 +43,50 @@ export default function AppInfo(props: Readonly<GroupProps>) {
     if (userData?.seenChangelog === false) mutate({ seenChangelog: true });
   };
 
+  const { classes } = useNavBtnStyle({ active: false });
+
   return (
     <>
-      <Group {...props} spacing="xs" position="center">
-        <Text
-          component={Link}
-          to={userData ? "/about-app" : "/about"}
-          td="underline"
-          fz="xs"
-          color="dimmed"
-        >
-          About
-        </Text>
-        <IconPoint size={12} />
-        <Text
-          td="underline"
-          sx={{ cursor: "pointer" }}
-          fz="xs"
-          color="dimmed"
-          onClick={open}
-        >
-          What's New?
-        </Text>
-      </Group>
+      {props.type === "text" && (
+        <Group {...props} spacing="xs" position={props.position ?? "center"}>
+          <Text
+            component={Link}
+            to={userData ? "/about-app" : "/about"}
+            td="underline"
+            fz="xs"
+            color="dimmed"
+          >
+            About
+          </Text>
+          <IconPoint size={12} />
+          <Text
+            td="underline"
+            sx={{ cursor: "pointer" }}
+            fz="xs"
+            color="dimmed"
+            onClick={open}
+          >
+            What's New?
+          </Text>
+        </Group>
+      )}
+      {props.type === "menu" && (
+        <Menu position="right-end">
+          <Menu.Target>
+            <UnstyledButton className={classes.navBtn} mt={props.mt}>
+              <ThemeIcon variant="default" size={36}>
+                <IconInfoCircle size={20} />
+              </ThemeIcon>
+            </UnstyledButton>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item component={Link} to="/about-app">
+              About
+            </Menu.Item>
+            <Menu.Item onClick={open}>What's New</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      )}
       <Modal
         centered
         onClose={handleClose}

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -4,6 +4,7 @@ import {
   IconDatabaseExport,
   IconReport,
   IconSearch,
+  IconUserCog,
 } from "@tabler/icons-react";
 
 export const ROUTES: RouteItem[] = [
@@ -41,5 +42,12 @@ export const ROUTES: RouteItem[] = [
     path: "/export",
     exactMatch: false,
     shortcut: "E",
+  },
+  {
+    icon: <IconUserCog size={16} />,
+    label: "My Account",
+    path: "/account",
+    exactMatch: false,
+    shortcut: "U",
   },
 ];

--- a/src/modules/auth/Login.tsx
+++ b/src/modules/auth/Login.tsx
@@ -148,7 +148,7 @@ export default function Login() {
             </Text>
           </Text>
         </Container>
-        <AppInfo mt="auto" />
+        <AppInfo mt="auto" type="text" />
       </Box>
     </PublicGuard>
   );

--- a/src/modules/auth/Register.tsx
+++ b/src/modules/auth/Register.tsx
@@ -146,7 +146,7 @@ export default function Register() {
             </Text>
           </Text>
         </Container>
-        <AppInfo mt="auto" />
+        <AppInfo mt="auto" type="text" />
       </Box>
     </PublicGuard>
   );

--- a/src/modules/home/BudgetBreakdown.tsx
+++ b/src/modules/home/BudgetBreakdown.tsx
@@ -221,7 +221,7 @@ export default function BudgetBreakdown({
         )}
       </Group>
       <Divider my="xs" />
-      <ScrollArea h={`calc(100vh - ${isMobile ? 272 : 242}px)`}>
+      <ScrollArea h={`calc(100vh - ${isMobile ? 272 : 247}px)`}>
         <SimpleGrid cols={1} spacing="xs">
           {Object.entries(summary?.response?.summary ?? {})?.map((item) => (
             <BudgetItem

--- a/src/modules/layout/AppNavigation.tsx
+++ b/src/modules/layout/AppNavigation.tsx
@@ -1,5 +1,4 @@
 import {
-  ActionIcon,
   Group,
   Kbd,
   Navbar,
@@ -11,7 +10,7 @@ import {
 import { HorizontalSectionSharedProps } from "@mantine/core/lib/AppShell/HorizontalSection/HorizontalSection";
 import { useHotkeys } from "@mantine/hooks";
 import { modals } from "@mantine/modals";
-import { IconLogout, IconPower, IconUserCog } from "@tabler/icons-react";
+import { IconLogout, IconPower } from "@tabler/icons-react";
 import { useMemo, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import AppInfo from "../../components/app-info/AppInfo";
@@ -32,6 +31,9 @@ type SidebarProps = Omit<HorizontalSectionSharedProps, "children"> &
 
 export default function AppNavigation({ onChange, ...rest }: SidebarProps) {
   const { classes } = useAppStyles();
+  const { classes: btnClasses } = useNavBtnStyle({ active: false });
+  const isMobile = useMediaMatch();
+
   const { logoutUser } = useLogoutHandler();
   const confirmLogout = () =>
     modals.openConfirmModal({
@@ -52,10 +54,10 @@ export default function AppNavigation({ onChange, ...rest }: SidebarProps) {
     });
   return (
     <Navbar
-      width={{ base: 300 }}
+      p="sm"
+      width={{ base: isMobile ? 300 : 60 }}
       hiddenBreakpoint="sm"
       className={classes.navigation}
-      p="md"
       {...rest}
     >
       <Navbar.Section
@@ -77,28 +79,23 @@ export default function AppNavigation({ onChange, ...rest }: SidebarProps) {
           alignItems: "center",
         })}
       >
-        <NavLink
-          icon={<IconUserCog size={16} />}
-          label="My Account"
-          path="/account"
-          shortcut="U"
-          exactMatch={false}
-          onChange={onChange}
-        />
-        <Tooltip label="Log Out" position="bottom" withArrow color="dark">
-          <ActionIcon
-            color="red"
-            variant="light"
-            size="lg"
-            radius="sm"
-            onClick={confirmLogout}
-          >
-            <IconPower size={20} />
-          </ActionIcon>
+        <Tooltip
+          label="Log Out"
+          position="right"
+          events={{ focus: true, hover: true, touch: false }}
+          disabled={isMobile}
+          offset={10}
+        >
+          <UnstyledButton onClick={confirmLogout} className={btnClasses.navBtn}>
+            <ThemeIcon variant={"light"} color="red" size={36}>
+              <IconPower size={20} />
+            </ThemeIcon>
+            {isMobile && <Text size="sm">Log Out</Text>}
+          </UnstyledButton>
         </Tooltip>
       </Navbar.Section>
       <Navbar.Section>
-        <AppInfo />
+        <AppInfo type={isMobile ? "text" : "menu"} mt="sm" position="left" />
       </Navbar.Section>
     </Navbar>
   );
@@ -123,20 +120,31 @@ function NavLink({ onChange, ...route }: NavLinkProps) {
   useHotkeys([[route.shortcut, navigateViaShortcut]]);
 
   return (
-    <UnstyledButton
-      ref={ref}
-      component={Link}
-      onClick={() => onChange(false)}
-      to={route.path}
-      className={classes.navBtn}
+    <Tooltip
+      label={
+        <Group spacing={6}>
+          <Text fz="sm">{route.label}</Text>
+          <Kbd ml="auto">{route.shortcut}</Kbd>
+        </Group>
+      }
+      width={170}
+      offset={10}
+      position="right"
+      disabled={isMobile}
+      events={{ focus: true, hover: true, touch: false }}
     >
-      <Group>
-        <ThemeIcon variant={active ? "filled" : "light"}>
+      <UnstyledButton
+        ref={ref}
+        component={Link}
+        onClick={() => onChange(false)}
+        to={route.path}
+        className={classes.navBtn}
+      >
+        <ThemeIcon variant={active ? "filled" : "light"} size={36}>
           {route.icon}
         </ThemeIcon>
-        <Text size="sm">{route.label}</Text>
-        {!isMobile && <Kbd ml="auto">{route.shortcut}</Kbd>}
-      </Group>
-    </UnstyledButton>
+        {isMobile && <Text size="sm">{route.label}</Text>}
+      </UnstyledButton>
+    </Tooltip>
   );
 }

--- a/src/theme/modules/layout.styles.ts
+++ b/src/theme/modules/layout.styles.ts
@@ -25,15 +25,15 @@ export const useShortcutBlockStyles = createStyles((theme) => ({
 export const useNavBtnStyle = createStyles(
   (theme, { active }: { active: boolean }) => ({
     navBtn: {
-      display: "block",
+      display: "flex",
+      alignItems: "center",
+      gap: theme.spacing.sm,
       width: "100%",
-      padding: theme.spacing.xs,
       borderRadius: theme.radius.sm,
       color: theme.colors.dark[0],
-      backgroundColor: active ? theme.colors.dark[5] : "transparent",
-      boxShadow: active ? theme.shadows.md : "none",
+      fontWeight: active ? "bold" : "normal",
       "&:hover": {
-        backgroundColor: active ? theme.colors.dark[5] : theme.colors.dark[8],
+        backgroundColor: theme.colors.dark[5],
       },
     },
   })


### PR DESCRIPTION
- Implement a narrow sidebar with icons-only design for desktop mode, without any change for mobile devices. 
- Move the user account link from the bottom section to the main navigation section. 
  - ![image](https://github.com/user-attachments/assets/041abfef-0960-4481-a2f7-77dd8e006eb7)
  - adds tooltip in the desktop view to provide the required info of shortcuts. 
  - ![image](https://github.com/user-attachments/assets/13ceef6c-7a90-4206-8883-8554e2709295)
- Implement a new icon-mode for app-info component in order to fit in the icon-only style sidebar. 
  - ![image](https://github.com/user-attachments/assets/424c0cd2-0601-4667-b061-2a2065f3d265)